### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2016 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/github-changelog
+@see https://github.com/ergebnis/github-changelog
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,57 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.6.1...master`][0.6.1...master]
+For a full diff see [`0.7.0...master`][0.7.0...master].
+
+## [`0.7.0`][0.7.0]
+
+For a full diff see [`0.6.1...0.7.0`][0.6.1...0.7.0].
+
+### Changed
+
+* Renamed namespace `Localheinz\GitHub\ChangeLog` to `Ergebnis\GitHub\Changelog` after move to [@ergebnis] ([#336]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/github-changelog
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/github-changelog
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\GitHub\\ChangeLog/Ergebnis\\GitHub\\Changelog/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\GitHub\ChangeLog` with `Ergebnis\GitHub\Changelog`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
 * Dropped support for PHP 7.1 ([#314]), by [@localheinz]
 
+[0.7.0]: https://github.com/ergebnis/github-changelog/tag/0.7.0
 
-[0.6.1...master]: https://github.com/localheinz/github-changelog/compare/0.6.1...master
+[0.6.1...0.7.0]: https://github.com/ergebnis/github-changelog/compare/0.6.1...0.7.0
+[0.7.0...master]: https://github.com/ergebnis/github-changelog/compare/0.7.0...master
 
-[#314]: https://github.com/localheinz/github-changelog/pull/314
+[#314]: https://github.com/ergebnis/github-changelog/pull/314
+[#336]: https://github.com/ergebnis/github-changelog/pull/336
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # github-changelog
 
-[![Continuous Integration](https://github.com/localheinz/github-changelog/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/github-changelog/actions)
-[![Test Coverage](https://codecov.io/gh/localheinz/github-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/github-changelog)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/github-changelog/v/stable)](https://packagist.org/packages/localheinz/github-changelog)
-[![Total Downloads](https://poser.pugx.org/localheinz/github-changelog/downloads)](https://packagist.org/packages/localheinz/github-changelog)
+[![Continuous Integration](https://github.com/ergebnis/github-changelog/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/github-changelog/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/github-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/github-changelog)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/github-changelog/v/stable)](https://packagist.org/packages/ergebnis/github-changelog)
+[![Total Downloads](https://poser.pugx.org/ergebnis/github-changelog/downloads)](https://packagist.org/packages/ergebnis/github-changelog)
 
 Provides a script that generates a changelog based on titles of pull requests merged between specified references.
 
@@ -50,13 +50,13 @@ All this tool does is this:
 Install globally:
 
 ```bash
-$ composer global require localheinz/github-changelog
+$ composer global require ergebnis/github-changelog
 ```
 
 Create your changelogs from within a Git repository:
 
 ```bash
-$ git clone git@github.com:localheinz/github-changelog.git
+$ git clone git@github.com:ergebnis/github-changelog.git
 $ cd github-changelog
 $ github-changelog generate 0.1.1 0.1.2
 ```
@@ -64,7 +64,7 @@ $ github-changelog generate 0.1.1 0.1.2
 Create your changelogs from anywhere, specifying the repository using the `--repository` option:
 
 ```bash
-$ github-changelog generate --repository localheinz/github-changelog 0.1.1 0.1.2
+$ github-changelog generate --repository ergebnis/github-changelog 0.1.1 0.1.2
 ```
 
 Enjoy the changelog:
@@ -79,13 +79,13 @@ Enjoy the changelog:
 Install locally:
 
 ```bash
-$ composer require --dev localheinz/github-changelog
+$ composer require --dev ergebnis/github-changelog
 ```
 
 Create your changelog from within in your project:
 
 ```bash
-$ vendor/bin/github-changelog generate localheinz/github-changelog ae63248 master
+$ vendor/bin/github-changelog generate ergebnis/github-changelog ae63248 master
 ```
 
 Enjoy the changelog:
@@ -106,7 +106,7 @@ Enjoy the changelog:
 Install locally:
 
 ```bash
-$ composer require localheinz/github-changelog
+$ composer require ergebnis/github-changelog
 ```
 
 Retrieve pull requests between references in your application:
@@ -118,8 +118,8 @@ require 'vendor/autoload.php';
 
 use Github\Client;
 use Github\HttpClient\CachedHttpClient;
-use Localheinz\GitHub\ChangeLog\Repository;
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\ChangeLog\Repository;
+use Ergebnis\GitHub\ChangeLog\Resource;
 
 $client = new Client(new CachedHttpClient());
 $client->authenticate(
@@ -134,7 +134,7 @@ $pullRequestRepository = new Repository\PullRequestRepository(
 
 /* @var Resource\RangeInterface $range */
 $range = $repository->items(
-    Resource\Repository::fromString('localheinz/github-changelog'),
+    Resource\Repository::fromString('ergebnis/github-changelog'),
     '0.1.1',
     '0.1.2'
 );

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "localheinz/github-changelog",
+  "name": "ergebnis/github-changelog",
   "description": "Provides a console command that generates a changelog based on titles of pull requests merged between specified references.",
-  "homepage": "https://github.com/localheinz/github-changelog",
+  "homepage": "https://github.com/ergebnis/github-changelog",
   "license": "MIT",
   "authors": [
     {
@@ -16,6 +16,9 @@
     "symfony/cache": "^4.3.8",
     "symfony/console": "^4.3.8",
     "symfony/stopwatch": "^4.4.1"
+  },
+  "replace": {
+    "localheinz/github-changelog": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
@@ -36,19 +39,19 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\GitHub\\ChangeLog\\": "src"
+      "Ergebnis\\GitHub\\Changelog\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\GitHub\\ChangeLog\\Test\\": "test"
+      "Ergebnis\\GitHub\\Changelog\\Test\\": "test"
     }
   },
   "bin": [
     "github-changelog"
   ],
   "support": {
-    "issues": "https://github.com/localheinz/github-changelog/issues",
-    "source": "https://github.com/localheinz/github-changelog"
+    "issues": "https://github.com/ergebnis/github-changelog/issues",
+    "source": "https://github.com/ergebnis/github-changelog"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b557b8ad571f1983127b7c5cd597109",
+    "content-hash": "f5743c2421c49c2d1f01493140d0b406",
     "packages": [
         {
             "name": "clue/stream-filter",

--- a/github-changelog.php
+++ b/github-changelog.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
+use Ergebnis\GitHub\ChangeLog;
 use Github\Api;
 use Github\Client;
-use Localheinz\GitHub\ChangeLog;
 use Symfony\Component\Cache;
 use Symfony\Component\Console;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,72 +3,72 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Console\\\\GenerateCommand\\:\\:range\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Console\\\\GenerateCommand\\:\\:range\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
 			count: 1
 			path: src/Console/GenerateCommand.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Console\\\\GenerateCommand\\:\\:range\\(\\) has parameter \\$endReference with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Console\\\\GenerateCommand\\:\\:range\\(\\) has parameter \\$endReference with null as default value\\.$#"
 			count: 1
 			path: src/Console/GenerateCommand.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\CommitRepository\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\CommitRepository\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
 			count: 1
 			path: src/Repository/CommitRepository.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\CommitRepository\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\CommitRepository\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
 			count: 1
 			path: src/Repository/CommitRepository.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\CommitRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\CommitRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
 			count: 1
 			path: src/Repository/CommitRepositoryInterface.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\CommitRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\CommitRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
 			count: 1
 			path: src/Repository/CommitRepositoryInterface.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\PullRequestRepository\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\PullRequestRepository\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
 			count: 1
 			path: src/Repository/PullRequestRepository.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\PullRequestRepository\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\PullRequestRepository\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
 			count: 1
 			path: src/Repository/PullRequestRepository.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\PullRequestRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\PullRequestRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with a nullable type declaration\\.$#"
 			count: 1
 			path: src/Repository/PullRequestRepositoryInterface.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Repository\\\\PullRequestRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Repository\\\\PullRequestRepositoryInterface\\:\\:items\\(\\) has parameter \\$endReference with null as default value\\.$#"
 			count: 1
 			path: src/Repository/PullRequestRepositoryInterface.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$message with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$message with a nullable type declaration\\.$#"
 			count: 1
 			path: test/Unit/Repository/CommitRepositoryTest.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$message with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$message with null as default value\\.$#"
 			count: 1
 			path: test/Unit/Repository/CommitRepositoryTest.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$sha with a nullable type declaration\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$sha with a nullable type declaration\\.$#"
 			count: 1
 			path: test/Unit/Repository/CommitRepositoryTest.php
 
 		-
-			message: "#^Method Localheinz\\\\GitHub\\\\ChangeLog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$sha with null as default value\\.$#"
+			message: "#^Method Ergebnis\\\\GitHub\\\\Changelog\\\\Test\\\\Unit\\\\Repository\\\\CommitRepositoryTest\\:\\:commitItem\\(\\) has parameter \\$sha with null as default value\\.$#"
 			count: 1
 			path: test/Unit/Repository/CommitRepositoryTest.php
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -8,16 +8,16 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Console;
+namespace Ergebnis\GitHub\Changelog\Console;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Repository;
+use Ergebnis\GitHub\Changelog\Resource;
+use Ergebnis\GitHub\Changelog\Util;
 use Github\Client;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Repository;
-use Localheinz\GitHub\ChangeLog\Resource;
-use Localheinz\GitHub\ChangeLog\Util;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input;
@@ -86,7 +86,7 @@ final class GenerateCommand extends Command
                 'repository',
                 'r',
                 Input\InputOption::VALUE_REQUIRED,
-                'The repository, e.g. "localheinz/github-changelog"'
+                'The repository, e.g. "ergebnis/github-changelog"'
             )
             ->addOption(
                 'template',

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Exception;
+namespace Ergebnis\GitHub\Changelog\Exception;
 
 interface ExceptionInterface
 {

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Exception;
+namespace Ergebnis\GitHub\Changelog\Exception;
 
 final class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {

--- a/src/Exception/PullRequestNotFound.php
+++ b/src/Exception/PullRequestNotFound.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Exception;
+namespace Ergebnis\GitHub\Changelog\Exception;
 
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Resource;
 
 final class PullRequestNotFound extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/ReferenceNotFound.php
+++ b/src/Exception/ReferenceNotFound.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Exception;
+namespace Ergebnis\GitHub\Changelog\Exception;
 
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Resource;
 
 final class ReferenceNotFound extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Exception;
+namespace Ergebnis\GitHub\Changelog\Exception;
 
 final class RuntimeException extends \RuntimeException implements ExceptionInterface
 {

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Repository;
+namespace Ergebnis\GitHub\Changelog\Repository;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
 
 final class CommitRepository implements CommitRepositoryInterface
 {

--- a/src/Repository/CommitRepositoryInterface.php
+++ b/src/Repository/CommitRepositoryInterface.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Repository;
+namespace Ergebnis\GitHub\Changelog\Repository;
 
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 
 interface CommitRepositoryInterface
 {

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Repository;
+namespace Ergebnis\GitHub\Changelog\Repository;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
 
 final class PullRequestRepository implements PullRequestRepositoryInterface
 {

--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Repository;
+namespace Ergebnis\GitHub\Changelog\Repository;
 
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 
 interface PullRequestRepositoryInterface
 {

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
-use Localheinz\GitHub\ChangeLog\Exception;
+use Ergebnis\GitHub\Changelog\Exception;
 
 final class Commit implements CommitInterface
 {

--- a/src/Resource/CommitInterface.php
+++ b/src/Resource/CommitInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 interface CommitInterface
 {

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
-use Localheinz\GitHub\ChangeLog\Exception;
+use Ergebnis\GitHub\Changelog\Exception;
 
 final class PullRequest implements PullRequestInterface
 {

--- a/src/Resource/PullRequestInterface.php
+++ b/src/Resource/PullRequestInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 interface PullRequestInterface
 {

--- a/src/Resource/Range.php
+++ b/src/Resource/Range.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 final class Range implements RangeInterface
 {

--- a/src/Resource/RangeInterface.php
+++ b/src/Resource/RangeInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 interface RangeInterface
 {

--- a/src/Resource/Repository.php
+++ b/src/Resource/Repository.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
-use Localheinz\GitHub\ChangeLog\Exception;
+use Ergebnis\GitHub\Changelog\Exception;
 
 final class Repository implements RepositoryInterface
 {

--- a/src/Resource/RepositoryInterface.php
+++ b/src/Resource/RepositoryInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 interface RepositoryInterface
 {

--- a/src/Resource/User.php
+++ b/src/Resource/User.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 final class User implements UserInterface
 {

--- a/src/Resource/UserInterface.php
+++ b/src/Resource/UserInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Resource;
+namespace Ergebnis\GitHub\Changelog\Resource;
 
 interface UserInterface
 {

--- a/src/Util/Git.php
+++ b/src/Util/Git.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Util;
+namespace Ergebnis\GitHub\Changelog\Util;
 
-use Localheinz\GitHub\ChangeLog\Exception;
+use Ergebnis\GitHub\Changelog\Exception;
 
 final class Git implements GitInterface
 {

--- a/src/Util/GitInterface.php
+++ b/src/Util/GitInterface.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Util;
+namespace Ergebnis\GitHub\Changelog\Util;
 
-use Localheinz\GitHub\ChangeLog\Exception;
+use Ergebnis\GitHub\Changelog\Exception;
 
 interface GitInterface
 {

--- a/src/Util/RepositoryResolver.php
+++ b/src/Util/RepositoryResolver.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Util;
+namespace Ergebnis\GitHub\Changelog\Util;
 
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 
 final class RepositoryResolver implements RepositoryResolverInterface
 {

--- a/src/Util/RepositoryResolverInterface.php
+++ b/src/Util/RepositoryResolverInterface.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Util;
+namespace Ergebnis\GitHub\Changelog\Util;
 
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 
 interface RepositoryResolverInterface
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\AutoReview;
+namespace Ergebnis\GitHub\Changelog\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\GitHub\\ChangeLog\\',
-            'Localheinz\\GitHub\\ChangeLog\\Test\\Unit\\'
+            'Ergebnis\\GitHub\\Changelog\\',
+            'Ergebnis\\GitHub\\Changelog\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Console;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Console;
 
+use Ergebnis\GitHub\Changelog\Console;
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Repository;
+use Ergebnis\GitHub\Changelog\Resource;
+use Ergebnis\GitHub\Changelog\Util;
 use Ergebnis\Test\Util\Helper;
 use Github\Client;
-use Localheinz\GitHub\ChangeLog\Console;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Repository;
-use Localheinz\GitHub\ChangeLog\Resource;
-use Localheinz\GitHub\ChangeLog\Util;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input;
@@ -28,7 +28,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Console\GenerateCommand
+ * @covers \Ergebnis\GitHub\Changelog\Console\GenerateCommand
  */
 final class GenerateCommandTest extends Framework\TestCase
 {
@@ -57,7 +57,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerGenerateCommandArgument
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerGenerateCommandArgument
      *
      * @param string $name
      * @param bool   $isRequired
@@ -104,7 +104,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerGenerateCommandOption
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerGenerateCommandOption
      *
      * @param string $name
      * @param string $shortcut
@@ -133,7 +133,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteAuthenticatesIfTokenOptionIsGiven(): void
     {
@@ -197,7 +197,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteFailsIfRepositoryIsInvalid(): void
     {
@@ -259,7 +259,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteDelegatesToPullRequestRepositoryUsingRepositoryResolvedFromGitMetaData(): void
     {
@@ -319,7 +319,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteDelegatesToPullRequestRepositoryUsingRepositorySpecifiedInOptions(): void
     {
@@ -376,7 +376,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteRendersMessageIfNoPullRequestsWereFound(): void
     {
@@ -432,7 +432,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteRendersDifferentMessageIfNoPullRequestsWereFoundAndNoEndReferenceWasGiven(): void
     {
@@ -488,9 +488,9 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\PullRequest
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      */
     public function testExecuteRendersPullRequestsWithTemplate(): void
     {
@@ -580,9 +580,9 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\PullRequest
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      */
     public function testExecuteRendersDifferentMessageWhenNoEndReferenceWasGiven(): void
     {
@@ -646,7 +646,7 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testExecuteHandlesExceptionsThrownWhenFetchingPullRequests(): void
     {

--- a/test/Unit/Exception/InvalidArgumentExceptionTest.php
+++ b/test/Unit/Exception/InvalidArgumentExceptionTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Exception;
 
+use Ergebnis\GitHub\Changelog\Exception\ExceptionInterface;
+use Ergebnis\GitHub\Changelog\Exception\InvalidArgumentException;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
-use Localheinz\GitHub\ChangeLog\Exception\InvalidArgumentException;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Exception\InvalidArgumentException
+ * @covers \Ergebnis\GitHub\Changelog\Exception\InvalidArgumentException
  */
 final class InvalidArgumentExceptionTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Exception;
 
+use Ergebnis\GitHub\Changelog\Exception\ExceptionInterface;
+use Ergebnis\GitHub\Changelog\Exception\PullRequestNotFound;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
-use Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound
+ * @covers \Ergebnis\GitHub\Changelog\Exception\PullRequestNotFound
  */
 final class PullRequestNotFoundTest extends Framework\TestCase
 {
@@ -39,7 +39,7 @@ final class PullRequestNotFoundTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testFromRepositoryAndNumberCreatesException(): void
     {

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -8,21 +8,21 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Exception;
 
+use Ergebnis\GitHub\Changelog\Exception\ExceptionInterface;
+use Ergebnis\GitHub\Changelog\Exception\ReferenceNotFound;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
-use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
+ * @covers \Ergebnis\GitHub\Changelog\Exception\ReferenceNotFound
  */
 final class ReferenceNotFoundTest extends Framework\TestCase
 {
@@ -39,7 +39,7 @@ final class ReferenceNotFoundTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testFromRepositoryAndReferenceCreatesException(): void
     {

--- a/test/Unit/Exception/RuntimeExceptionTest.php
+++ b/test/Unit/Exception/RuntimeExceptionTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Exception;
 
+use Ergebnis\GitHub\Changelog\Exception\ExceptionInterface;
+use Ergebnis\GitHub\Changelog\Exception\RuntimeException;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
-use Localheinz\GitHub\ChangeLog\Exception\RuntimeException;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Exception\RuntimeException
+ * @covers \Ergebnis\GitHub\Changelog\Exception\RuntimeException
  */
 final class RuntimeExceptionTest extends Framework\TestCase
 {

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -8,23 +8,23 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Repository;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Repository;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Repository;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Repository;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Repository\CommitRepository
+ * @covers \Ergebnis\GitHub\Changelog\Repository\CommitRepository
  */
 final class CommitRepositoryTest extends Framework\TestCase
 {
@@ -36,8 +36,8 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess(): void
     {
@@ -75,8 +75,8 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Exception\ReferenceNotFound
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testShowThrowsCommitNotFoundOnFailure(): void
     {
@@ -111,8 +111,8 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testAllReturnsEmptyArrayOnFailure(): void
     {
@@ -147,9 +147,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testAllSetsParamsPerPageTo250(): void
     {
@@ -183,9 +183,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testAllStillAllowsSettingPerPage(): void
     {
@@ -221,9 +221,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testAllReturnsRange(): void
     {
@@ -273,8 +273,8 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame(): void
     {
@@ -302,9 +302,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Exception\ReferenceNotFound
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound(): void
     {
@@ -346,10 +346,10 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Exception\ReferenceNotFound
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound(): void
     {
@@ -400,9 +400,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsFetchesCommitsUsingShaFromEndCommit(): void
     {
@@ -458,9 +458,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsFetchesCommitsIfEndReferenceIsNotGiven(): void
     {
@@ -503,9 +503,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsReturnsRangeOfCommitsFromEndToStartExcludingStart(): void
     {
@@ -599,9 +599,9 @@ final class CommitRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Range
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsFetchesMoreCommitsIfEndIsNotContainedInFirstBatch(): void
     {

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -8,23 +8,23 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Repository;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Repository;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Repository;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Repository;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 use Prophecy\Argument;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Repository\PullRequestRepository
+ * @covers \Ergebnis\GitHub\Changelog\Repository\PullRequestRepository
  */
 final class PullRequestRepositoryTest extends Framework\TestCase
 {
@@ -36,9 +36,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\PullRequest
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      */
     public function testShowReturnsPullRequestEntityWithNumberTitleAndAuthorOnSuccess(): void
     {
@@ -78,8 +78,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Exception\PullRequestNotFound
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testShowThrowsPullRequestNotFoundOnFailure(): void
     {
@@ -122,7 +122,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotRequireAnEndReference(): void
     {
@@ -165,7 +165,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotTouchRangeIfNoCommitsWereFound(): void
     {
@@ -214,8 +214,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsDoesNotTouchRangeIfNoMergeCommitsWereFound(): void
     {
@@ -271,10 +271,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\PullRequest
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      */
     public function testItemsFetchesPullRequestIfMergeCommitWasFound(): void
     {
@@ -351,10 +351,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Exception\PullRequestNotFound
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Commit
+     * @uses \Ergebnis\GitHub\Changelog\Resource\PullRequest
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testItemsHandlesMergeCommitWherePullRequestWasNotFound(): void
     {

--- a/test/Unit/Resource/CommitTest.php
+++ b/test/Unit/Resource/CommitTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Resource;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\Commit
+ * @covers \Ergebnis\GitHub\Changelog\Resource\Commit
  */
 final class CommitTest extends Framework\TestCase
 {
@@ -33,7 +33,7 @@ final class CommitTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidSha
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidSha
      *
      * @param string $sha
      */

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Resource;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+ * @covers \Ergebnis\GitHub\Changelog\Resource\PullRequest
  */
 final class PullRequestTest extends Framework\TestCase
 {
@@ -33,9 +33,9 @@ final class PullRequestTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      *
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidPullRequestNumber
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidPullRequestNumber
      *
      * @param int $number
      */
@@ -60,7 +60,7 @@ final class PullRequestTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     * @uses \Ergebnis\GitHub\Changelog\Resource\User
      */
     public function testConstructorSetsValues(): void
     {

--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Resource;
 
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\Range
+ * @covers \Ergebnis\GitHub\Changelog\Resource\Range
  */
 final class RangeTest extends Framework\TestCase
 {

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Resource;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\Repository
+ * @covers \Ergebnis\GitHub\Changelog\Resource\Repository
  */
 final class RepositoryTest extends Framework\TestCase
 {
@@ -33,7 +33,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRepositoryOwner
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidRepositoryOwner
      *
      * @param string $owner
      */
@@ -56,7 +56,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRepositoryName
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidRepositoryName
      *
      * @param string $name
      */
@@ -79,7 +79,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerValidRepositoryOwnerAndName
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerValidRepositoryOwnerAndName
      *
      * @param string $owner
      * @param string $name
@@ -96,7 +96,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRemoteUrl
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidRemoteUrl
      *
      * @param string $remoteUrl
      */
@@ -112,7 +112,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerValidRemoteUrlOwnerAndName
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerValidRemoteUrlOwnerAndName
      *
      * @param string $remoteUrl
      * @param string $owner
@@ -148,7 +148,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRepositoryString
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidRepositoryString
      *
      * @param string $string
      */
@@ -164,7 +164,7 @@ final class RepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerValidRepositoryOwnerAndName
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerValidRepositoryOwnerAndName
      *
      * @param string $owner
      * @param string $name

--- a/test/Unit/Resource/UserTest.php
+++ b/test/Unit/Resource/UserTest.php
@@ -8,19 +8,19 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Resource;
 
+use Ergebnis\GitHub\Changelog\Resource;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\User
+ * @covers \Ergebnis\GitHub\Changelog\Resource\User
  */
 final class UserTest extends Framework\TestCase
 {

--- a/test/Unit/Util/GitTest.php
+++ b/test/Unit/Util/GitTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Util;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Util;
 
+use Ergebnis\GitHub\Changelog\Util\Git;
+use Ergebnis\GitHub\Changelog\Util\GitInterface;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Util\Git;
-use Localheinz\GitHub\ChangeLog\Util\GitInterface;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Util\Git
+ * @covers \Ergebnis\GitHub\Changelog\Util\Git
  */
 final class GitTest extends Framework\TestCase
 {

--- a/test/Unit/Util/RepositoryResolverTest.php
+++ b/test/Unit/Util/RepositoryResolverTest.php
@@ -8,22 +8,22 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Unit\Util;
+namespace Ergebnis\GitHub\Changelog\Test\Unit\Util;
 
+use Ergebnis\GitHub\Changelog\Exception;
+use Ergebnis\GitHub\Changelog\Util\GitInterface;
+use Ergebnis\GitHub\Changelog\Util\RepositoryResolver;
+use Ergebnis\GitHub\Changelog\Util\RepositoryResolverInterface;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\GitHub\ChangeLog\Exception;
-use Localheinz\GitHub\ChangeLog\Util\GitInterface;
-use Localheinz\GitHub\ChangeLog\Util\RepositoryResolver;
-use Localheinz\GitHub\ChangeLog\Util\RepositoryResolverInterface;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Util\RepositoryResolver
+ * @covers \Ergebnis\GitHub\Changelog\Util\RepositoryResolver
  */
 final class RepositoryResolverTest extends Framework\TestCase
 {
@@ -71,9 +71,9 @@ final class RepositoryResolverTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      *
-     * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRemoteUrl
+     * @dataProvider \Ergebnis\GitHub\Changelog\Test\Util\DataProvider::providerInvalidRemoteUrl
      *
      * @param string $remoteUrl
      */
@@ -109,7 +109,7 @@ final class RepositoryResolverTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testResolveWithoutFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrl(): void
     {
@@ -153,7 +153,7 @@ final class RepositoryResolverTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testResolveWithFromRemoteNamesThrowsRuntimeExceptionIfNoValidRemoteUrlsCanBeConsidered(): void
     {
@@ -197,7 +197,7 @@ final class RepositoryResolverTest extends Framework\TestCase
     }
 
     /**
-     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Ergebnis\GitHub\Changelog\Resource\Repository
      */
     public function testResolveWithFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrlIfItCanBeConsidered(): void
     {

--- a/test/Util/DataProvider.php
+++ b/test/Util/DataProvider.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/github-changelog
+ * @see https://github.com/ergebnis/github-changelog
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Util;
+namespace Ergebnis\GitHub\Changelog\Test\Util;
 
 use Ergebnis\Test\Util\Helper;
 
@@ -53,7 +53,7 @@ final class DataProvider
             'repository' => [
                 'r',
                 true,
-                'The repository, e.g. "localheinz/github-changelog"',
+                'The repository, e.g. "ergebnis/github-changelog"',
                 null,
             ],
             'template' => [


### PR DESCRIPTION
This PR

* [x] renames the namespace `Localheinz\GitHub\ChangeLog` to `Ergebnis\GitHub\Changelog` after the move to @ergebnis