### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.7.0...master`][0.7.0...master].
+For a full diff see [`0.7.1...master`][0.7.1...master].
+
+## [`0.7.1`][0.7.1]
+
+For a full diff see [`0.7.0...0.7.1`][0.7.0...0.7.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#339]), by [@localheinz]
 
 ## [`0.7.0`][0.7.0]
 
@@ -51,12 +59,15 @@ For a full diff see [`0.6.1...0.7.0`][0.6.1...0.7.0].
 * Dropped support for PHP 7.1 ([#314]), by [@localheinz]
 
 [0.7.0]: https://github.com/ergebnis/github-changelog/tag/0.7.0
+[0.7.1]: https://github.com/ergebnis/github-changelog/tag/0.7.0
 
 [0.6.1...0.7.0]: https://github.com/ergebnis/github-changelog/compare/0.6.1...0.7.0
-[0.7.0...master]: https://github.com/ergebnis/github-changelog/compare/0.7.0...master
+[0.7.0...0.7.1]: https://github.com/ergebnis/github-changelog/compare/0.7.0...0.7.1
+[0.7.1...master]: https://github.com/ergebnis/github-changelog/compare/0.7.1...master
 
 [#314]: https://github.com/ergebnis/github-changelog/pull/314
 [#336]: https://github.com/ergebnis/github-changelog/pull/336
+[#339]: https://github.com/ergebnis/github-changelog/pull/339
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,6 @@
     "symfony/console": "^4.3.8",
     "symfony/stopwatch": "^4.4.1"
   },
-  "replace": {
-    "localheinz/github-changelog": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5743c2421c49c2d1f01493140d0b406",
+    "content-hash": "12fc5b2c067737649af2fea18325787f",
     "packages": [
         {
             "name": "clue/stream-filter",


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #52.