### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -80,7 +80,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":octocat: Provides a command line tool that generates a changelog based on titles of pull requests merged between specified references."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.7.1...master`][0.7.1...master].
+For a full diff see [`0.7.1...main`][0.7.1...main].
 
 ## [`0.7.1`][0.7.1]
 
@@ -63,7 +63,7 @@ For a full diff see [`0.6.1...0.7.0`][0.6.1...0.7.0].
 
 [0.6.1...0.7.0]: https://github.com/ergebnis/github-changelog/compare/0.6.1...0.7.0
 [0.7.0...0.7.1]: https://github.com/ergebnis/github-changelog/compare/0.7.0...0.7.1
-[0.7.1...master]: https://github.com/ergebnis/github-changelog/compare/0.7.1...master
+[0.7.1...main]: https://github.com/ergebnis/github-changelog/compare/0.7.1...main
 
 [#314]: https://github.com/ergebnis/github-changelog/pull/314
 [#336]: https://github.com/ergebnis/github-changelog/pull/336

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # github-changelog
 
-[![Integrate](https://github.com/ergebnis/github-changelog/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/github-changelog/actions)
-[![Prune](https://github.com/ergebnis/github-changelog/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/github-changelog/actions)
-[![Release](https://github.com/ergebnis/github-changelog/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/github-changelog/actions)
-[![Renew](https://github.com/ergebnis/github-changelog/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/github-changelog/actions)
+[![Integrate](https://github.com/ergebnis/github-changelog/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/github-changelog/actions)
+[![Prune](https://github.com/ergebnis/github-changelog/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/github-changelog/actions)
+[![Release](https://github.com/ergebnis/github-changelog/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/github-changelog/actions)
+[![Renew](https://github.com/ergebnis/github-changelog/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/github-changelog/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/github-changelog/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/github-changelog)
+[![Code Coverage](https://codecov.io/gh/ergebnis/github-changelog/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/github-changelog)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/github-changelog/coverage.svg)](https://shepherd.dev/github/ergebnis/github-changelog)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/github-changelog/v/stable)](https://packagist.org/packages/ergebnis/github-changelog)
@@ -31,7 +31,7 @@ keeping a changelog as suggested at http://keepachangelog.com.
 | My process                                   | Will this tool work for me? |
 |----------------------------------------------|-----------------------------|
 | I need elaborate changelogs                  | No                          |
-| I push to `master`                           | No                          |
+| I push directly into the default branch      | No                          |
 | ![Rebase and merge][rebase-and-merge-button] | No                          |
 | ![Squash and merge][squash-and-merge-button] | No                          |
 | ![Merge pull request][merge-button]          | **Yes**                     |
@@ -91,7 +91,7 @@ $ composer require --dev ergebnis/github-changelog
 Create your changelog from within in your project:
 
 ```bash
-$ vendor/bin/github-changelog generate ergebnis/github-changelog ae63248 master
+$ vendor/bin/github-changelog generate ergebnis/github-changelog ae63248 main
 ```
 
 Enjoy the changelog:
@@ -179,7 +179,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.