### PR TITLE
Fix: Configure mutation scores via configuration file

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,8 +9,6 @@ on: # yamllint disable-line rule:truthy
       - "main"
 
 env:
-  MIN_COVERED_MSI: 90
-  MIN_MSI: 88
   PHP_EXTENSIONS: "mbstring"
 
 jobs:
@@ -371,7 +369,7 @@ jobs:
         run: "composer update --no-interaction --no-progress --no-suggest"
 
       - name: "Run mutation tests with pcov and infection/infection"
-        run: "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${{ env.MIN_COVERED_MSI }} --min-msi=${{ env.MIN_MSI }}"
+        run: "vendor/bin/infection --configuration=infection.json"
 
   merge:
     name: "Merge"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-MIN_COVERED_MSI:=90
-MIN_MSI:=88
-
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets
 
@@ -27,7 +24,7 @@ help: ## Displays this list of targets with descriptions
 .PHONY: mutation-tests
 mutation-tests: vendor ## Runs mutation tests with infection/infection
 	mkdir -p .build/infection
-	vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${MIN_COVERED_MSI} --min-msi=${MIN_MSI}
+	vendor/bin/infection --configuration=infection.json
 
 .PHONY: static-code-analysis
 static-code-analysis: vendor ## Runs a static code analysis with phpstan/phpstan and vimeo/psalm

--- a/infection.json
+++ b/infection.json
@@ -1,7 +1,10 @@
 {
+  "ignoreMsiWithNoMutations": true,
   "logs": {
     "text": ".build/infection/infection-log.txt"
   },
+  "minCoveredMsi": 90,
+  "minMsi": 88,
   "phpUnit": {
     "configDir": "test\/Unit"
   },


### PR DESCRIPTION
This PR

* [x] configures mutation scores for `infection/infection` via configuration file